### PR TITLE
fix: proper types

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "html-minifier-terser": "^5.1.1"
   },
   "devDependencies": {
+    "@types/html-minifier-terser": "^5.1.1",
     "eslint": "^7.9.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",


### PR DESCRIPTION
Using this as-is in VS Code gives the typings for v6 och html-minifier-terser, which has changed the API. This confused me when debugging :)

This PR sets the typings to match the version